### PR TITLE
[#3] feat: 공통 응답, 에러 포맷 작성

### DIFF
--- a/src/main/java/com/opportunity/deliveryservice/global/common/code/BaseErrorCode.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/common/code/BaseErrorCode.java
@@ -1,0 +1,12 @@
+package com.opportunity.deliveryservice.global.common.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+
+	HttpStatus getHttpStatus();
+
+	String getCode();
+
+	String getMessage();
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/common/code/ClientErrorCode.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/common/code/ClientErrorCode.java
@@ -1,0 +1,44 @@
+package com.opportunity.deliveryservice.global.common.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 클라이언트 요청에 대한 에러 코드를 정의합니다.
+ *
+ *  형식: OPPTY-[도메인코드]-[HTTP 상태코드]-[에러번호]
+ * 	도메인코드
+ * 	HTTP 상태코드 (3자리)
+ *	에러번호 (3자리): 도메인 내 개별 에러 식별 번호
+ *
+ * <p>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ClientErrorCode implements BaseErrorCode {
+
+	// 400 Bad Request
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "OPPTY-CMN-400-01", "입력값이 올바르지 않습니다."),
+	INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "OPPTY-CMN-400-02", "JSON 형식이 유효하지 않습니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "OPPTY-CMN-405-01", "허용되지 않은 HTTP 메서드입니다."),
+
+	// 401 Unauthorized
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "OPPTY-CMN-401-01", "인증이 필요한 요청입니다."),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "OPPTY-CMN-401-02", "유효하지 않은 인증 토큰입니다."),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "OPPTY-CMN-401-03", "만료된 인증 토큰입니다."),
+
+	// 403 Forbidden
+	FORBIDDEN(HttpStatus.FORBIDDEN, "OPPTY-CMN-403-01", "해당 요청에 대한 접근 권한이 없습니다."),
+
+	// 404 Not Found
+	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "OPPTY-CMN-404-01", "요청한 리소스를 찾을 수 없습니다."),
+
+	// 409 Conflict
+	CONFLICT(HttpStatus.CONFLICT, "OPPTY-CMN-409-01", "요청이 서버의 현재 상태와 충돌합니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/common/code/ServerErrorCode.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/common/code/ServerErrorCode.java
@@ -1,0 +1,33 @@
+package com.opportunity.deliveryservice.global.common.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 서버 요청에 대한 에러 코드를 정의합니다.
+ *
+ *  형식: OPPTY-[도메인코드]-[HTTP 상태코드]-[에러번호]
+ * 	도메인코드
+ * 	HTTP 상태코드 (3자리)
+ *	에러번호 (3자리): 도메인 내 개별 에러 식별 번호
+ *
+ * <p>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ServerErrorCode implements BaseErrorCode {
+
+	// 500 Internal Server Error
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OPPTY-CMN-500-01", "서버 내부 오류가 발생했습니다. 관리자에게 문의해주세요."),
+	DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OPPTY-CMN-500-02", "데이터베이스 처리 중 오류가 발생했습니다."),
+
+	// 503 Service Unavailable
+	SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "OPPTY-CMN-503-01", "현재 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해주세요.");
+
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/common/exception/OpptyException.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/common/exception/OpptyException.java
@@ -1,0 +1,21 @@
+package com.opportunity.deliveryservice.global.common.exception;
+
+import com.opportunity.deliveryservice.global.common.code.BaseErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class OpptyException extends RuntimeException {
+
+	private final BaseErrorCode errorCode;
+
+	public OpptyException(BaseErrorCode errorCode) {
+		super();
+		this.errorCode = errorCode;
+	}
+
+	public OpptyException(BaseErrorCode errorCode, Throwable cause) {
+		super(cause);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/common/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,61 @@
+package com.opportunity.deliveryservice.global.common.exception.handler;
+
+import org.aspectj.bridge.MessageUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.opportunity.deliveryservice.global.common.code.BaseErrorCode;
+import com.opportunity.deliveryservice.global.common.code.ClientErrorCode;
+import com.opportunity.deliveryservice.global.common.code.ServerErrorCode;
+import com.opportunity.deliveryservice.global.common.exception.OpptyException;
+import com.opportunity.deliveryservice.global.common.response.ApiResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(OpptyException.class)
+	public ResponseEntity<ApiResponse<Void>> handleOpptyException(OpptyException ex) {
+		BaseErrorCode errorCode = ex.getErrorCode();
+		log.warn("OpptyException occurred: code={}, message={}", errorCode.getCode(), errorCode.getMessage(), ex);
+		return buildErrorResponse(errorCode);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<Void>> handleGeneralError(Exception ex) {
+		log.error("Unexpected error occurred", ex);
+		ServerErrorCode errorCode = ServerErrorCode.INTERNAL_SERVER_ERROR;
+		return buildErrorResponse(errorCode);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+		ClientErrorCode errorCode = ClientErrorCode.INVALID_INPUT_VALUE;
+
+		String validationMessage = ex.getBindingResult()
+			.getFieldErrors()
+			.stream()
+			.findFirst()
+			.map(FieldError::getDefaultMessage)
+			.filter(StringUtils::hasText)
+			.orElse(errorCode.getMessage());
+
+		return ResponseEntity.badRequest().body(ApiResponse.fail(errorCode.getCode(), validationMessage));
+	}
+
+	private ResponseEntity<ApiResponse<Void>> buildErrorResponse(BaseErrorCode errorCode) {
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(ApiResponse.fail(errorCode.getCode(), errorCode.getMessage()));
+	}
+
+	private ResponseEntity<ApiResponse<Void>> buildErrorResponse(BaseErrorCode errorCode, String customMessage) {
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(ApiResponse.fail(errorCode.getCode(), customMessage));
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/common/response/ApiResponse.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/common/response/ApiResponse.java
@@ -1,0 +1,68 @@
+package com.opportunity.deliveryservice.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"code", "message", "data"})
+public class ApiResponse<T> {
+
+	/**
+	 * 커스텀 에러 코드. 성공 시 null
+	 * 예: "OPPTY-CMN-403-001"
+	 */
+	private final String code;
+
+	/**
+	 * 사용자에게 보여줄 메시지. 주로 에러 발생 시 사용
+	 */
+	private final String message;
+
+	/**
+	 * 응답 본문 데이터. 성공 시 실제 결과 객체가 담김
+	 */
+	private final T data;
+
+	/**
+	 * 전체 생성자. 응답의 모든 필드를 지정하여 생성합니다.
+	 */
+	public ApiResponse(String code, String message, T data) {
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+
+	/**
+	 * 성공 응답을 생성합니다.
+	 */
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(null, null, data);
+	}
+
+	/**
+	 * 본문 없이 성공 응답 (No Content)을 생성합니다.
+	 */
+	public static <T> ApiResponse<T> noContent() {
+		return new ApiResponse<>(null, null, null);
+	}
+
+	/**
+	 * 응답 데이터가 없는 실패 응답을 생성합니다.
+	 */
+	public static <T> ApiResponse<T> fail(String code, String message) {
+		return new ApiResponse<>(code, message, null);
+	}
+
+	/**
+	 * 실패 응답을 생성합니다.
+	 */
+	public static <T> ApiResponse<T> fail(String code, String message, T data) {
+		return new ApiResponse<>(code, message, data);
+	}
+
+
+}
+


### PR DESCRIPTION
## 🚩 관련 이슈
- 에러 및 응답 코드 포맷 작성

## 📋 구현 기능 명세
- [x] 에러 코드 작성
- [x] 응답 코드 작성

## 📌 PR Point
- 응답 예시) ReponseEntity.ok(ApiResponse.success(데이터));
- 응답 예시) ReponseEntity.ok(ApiResponse.noContent());
- 에러 사용 시에 클라이언트 요청으로 오는 에러라면 ClientErrorCode에 에러를 추가하고 throw new OpptyException(추가한 에러 이름)