### PR TITLE
[#17]feat: 회원 관련 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'com.opportunity'
 version = '0.0.1-SNAPSHOT'
-description = 'delivery-service'
+description = 'deliveryservice'
 
 java {
     toolchain {
@@ -43,6 +43,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // JWT
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
@@ -51,12 +52,16 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'com.google.genai:google-genai:1.0.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/opportunity/deliveryservice/global/common/code/ClientErrorCode.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/common/code/ClientErrorCode.java
@@ -27,16 +27,24 @@ public enum ClientErrorCode implements BaseErrorCode {
 	// 401 Unauthorized
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "OPPTY-CMN-401-01", "인증이 필요한 요청입니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "OPPTY-CMN-401-02", "유효하지 않은 인증 토큰입니다."),
-	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "OPPTY-CMN-401-03", "만료된 인증 토큰입니다."),
+	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "OPPTY-CMN-401-03", "만료된 Access Token 토큰입니다. 토큰 재발급이 필요합니다."),
+	BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "OPPTY-CMN-401-04", "무효화된 토큰입니다. 다시 로그인 해주세요."), // 로그아웃, 재발급된 토큰
 
 	// 403 Forbidden
 	FORBIDDEN(HttpStatus.FORBIDDEN, "OPPTY-CMN-403-01", "해당 요청에 대한 접근 권한이 없습니다."),
+	UNAUTHORIZED_ROLE_CHANGE(HttpStatus.FORBIDDEN, "OPPTY-USR-403-01", "권한을 변경할 수 있는 권한이 없습니다."),
 
 	// 404 Not Found
 	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "OPPTY-CMN-404-01", "요청한 리소스를 찾을 수 없습니다."),
+	ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "OPPTY-ADD-404-01", "주소록을 찾을 수 없습니다."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "OPPTY-USR-404-01", "사용자를 찾을 수 없습니다."),
 
 	// 409 Conflict
-	CONFLICT(HttpStatus.CONFLICT, "OPPTY-CMN-409-01", "요청이 서버의 현재 상태와 충돌합니다.");
+	CONFLICT(HttpStatus.CONFLICT, "OPPTY-CMN-409-01", "요청이 서버의 현재 상태와 충돌합니다."),
+	DUPLICATE_USERNAME(HttpStatus.CONFLICT, "OPPTY-USR-409-01", "이미 존재하는 아이디입니다."),
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "OPPTY-USR-409-02", "이미 존재하는 이메일입니다."),
+	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "OPPTY-USR-409-03", "아이디 또는 비밀번호가 일치하지 않습니다."),
+	INVALID_ADMIN_KEY(HttpStatus.FORBIDDEN, "OPPTY-USR-409-04", "유효하지 않은 관리자 인증 키입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/opportunity/deliveryservice/global/common/response/ApiResponse.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/common/response/ApiResponse.java
@@ -43,6 +43,13 @@ public class ApiResponse<T> {
 	}
 
 	/**
+	 * 성공 응답 (데이터 없이 메시지만)
+	 */
+	public static <T> ApiResponse<T> successNoData(String code, String message) {
+		return new ApiResponse<>(code, message, null);
+	}
+
+	/**
 	 * 본문 없이 성공 응답 (No Content)을 생성합니다.
 	 */
 	public static <T> ApiResponse<T> noContent() {
@@ -62,7 +69,6 @@ public class ApiResponse<T> {
 	public static <T> ApiResponse<T> fail(String code, String message, T data) {
 		return new ApiResponse<>(code, message, data);
 	}
-
 
 }
 

--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,155 @@
+package com.opportunity.deliveryservice.global.infrastructure.config.security;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opportunity.deliveryservice.global.common.code.ClientErrorCode;
+import com.opportunity.deliveryservice.global.common.response.ApiResponse;
+import com.opportunity.deliveryservice.global.infrastructure.jwt.JwtUtil;
+import com.opportunity.deliveryservice.global.infrastructure.redis.RedisService;
+import com.opportunity.deliveryservice.user.domain.entity.User;
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserLoginRequestDto;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+	private final JwtUtil jwtUtil;
+	private final RedisService redisService;
+
+	public JwtAuthenticationFilter(JwtUtil jwtUtil, RedisService redisService) {
+		this.jwtUtil = jwtUtil;
+		this.redisService = redisService;
+		setFilterProcessesUrl("/v1/users/login");
+	}
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws
+		AuthenticationException {
+		try {
+			UserLoginRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(),
+				UserLoginRequestDto.class);
+
+			return getAuthenticationManager().authenticate(
+				new UsernamePasswordAuthenticationToken(
+					requestDto.getUsername(),
+					requestDto.getPassword(),
+					null
+				)
+			);
+		} catch (IOException e) {
+			log.error("인증 시도 중 입력 오류: {}", e.getMessage());
+			throw new RuntimeException("로그인 요청 처리 실패", e);
+		}
+	}
+
+	//로그인 성공 시 실행
+	@Override
+	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+		Authentication authResult) {
+		User user = ((UserDetailsImpl)authResult.getPrincipal()).getUser();
+		String username = user.getUsername();
+		UserRoleEnum role = user.getRole();
+
+		// 이전 토큰 전부 무효화
+		invalidatePreviousTokens(request, username);
+
+		// 1. Access Token 생성 및 Header에 저장 (30분, Header)
+		String accessToken = jwtUtil.createAccessToken(username, role);
+		response.addHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
+
+		// 2. Refresh Token 생성 (14일)
+		String refreshToken = jwtUtil.createRefreshToken(username, role);
+
+		// 3. Refresh Token을 HttpOnly 쿠키에 저장 (7일)
+		Cookie refreshTokenCookie = jwtUtil.createRefreshTokenCookie(refreshToken);
+		response.addCookie(refreshTokenCookie);
+
+		// 4. Refresh Token을 Redis에 저장 (14일 TTL)
+		long rtExpirationMs = jwtUtil.getExpirationRemainingTime(refreshToken);
+		redisService.setRefreshToken(username, refreshToken, Duration.ofMillis(rtExpirationMs));
+
+		log.info("로그인 성공: AT, RT 발급 및 Redis 저장 완료. User: {}", username);
+	}
+
+	private void invalidatePreviousTokens(HttpServletRequest request, String username) {
+
+		// 1. 이전 Access Token 무효화 (헤더에서 추출)
+		String previousAccessToken = JwtUtil.getJwtFromHeader(request);
+		if (StringUtils.hasText(previousAccessToken)) {
+			try {
+				// 이전 AT의 JTI를 추출하고 블랙리스트에 등록
+				String jti = jwtUtil.getJtiFromToken(previousAccessToken);
+				long ttl = jwtUtil.getExpirationRemainingTime(previousAccessToken);
+				if (ttl > 0) {
+					redisService.setBlacklist(jti, Duration.ofMillis(ttl));
+					log.warn("새 로그인 성공: 이전 Access Token 블랙리스트 등록 완료. JTI: {}", jti);
+				}
+			} catch (Exception e) {
+				// AT가 이미 만료되었거나 유효하지 않아 JTI 추출에 실패하면 무시
+				log.debug("이전 Access Token 무효화 중 오류 발생 (이미 만료 또는 손상): {}", e.getMessage());
+			}
+		}
+
+		// 2. 이전 Refresh Token 무효화 (쿠키에서 추출 및 JTI 블랙리스트 등록)
+		String previousRefreshToken = getRefreshTokenFromCookie(request);
+
+		if (StringUtils.hasText(previousRefreshToken)) {
+			try {
+				// 이전 RT의 JTI를 추출하고 블랙리스트에 등록
+				String jti = jwtUtil.getJtiFromToken(previousRefreshToken);
+				long ttl = jwtUtil.getExpirationRemainingTime(previousRefreshToken);
+				if (ttl > 0) {
+					redisService.setBlacklist(jti, Duration.ofMillis(ttl));
+					log.warn("새 로그인 성공: 이전 Refresh Token 블랙리스트 등록 완료. JTI: {}", jti);
+				}
+			} catch (Exception e) {
+				// RT가 이미 만료되었거나 유효하지 않아 JTI 추출에 실패하면 무시
+				log.debug("이전 Refresh Token 무효화 중 오류 발생 (이미 만료 또는 손상): {}", e.getMessage());
+			}
+		}
+	}
+
+	/**
+	 * 요청 쿠키에서 Refresh Token 값을 추출하는 헬퍼 메서드
+	 */
+	private String getRefreshTokenFromCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(JwtUtil.REFRESH_TOKEN_COOKIE_NAME)) {
+					return cookie.getValue();
+				}
+			}
+		}
+		return null;
+	}
+
+	// 로그인 실패 시 실행
+	@Override
+	protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException failed) throws IOException {
+		log.error("로그인 실패: {}", failed.getMessage());
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType("application/json;charset=UTF-8");
+		response.getWriter().write(new ObjectMapper().writeValueAsString(
+			new ApiResponse<>(
+				ClientErrorCode.INVALID_PASSWORD.getCode(),
+				ClientErrorCode.INVALID_PASSWORD.getMessage(),
+				null
+			)
+		));
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/JwtAuthorizationFilter.java
@@ -1,0 +1,103 @@
+package com.opportunity.deliveryservice.global.infrastructure.config.security;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opportunity.deliveryservice.global.common.code.ClientErrorCode;
+import com.opportunity.deliveryservice.global.common.response.ApiResponse;
+import com.opportunity.deliveryservice.global.infrastructure.jwt.JwtUtil;
+import com.opportunity.deliveryservice.global.infrastructure.redis.RedisService;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+	private final UserDetailsServiceImpl userDetailsService;
+	private final RedisService redisService; // 1. RedisService 추가 주입
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws
+		ServletException,
+		IOException {
+
+		String tokenValue = JwtUtil.getJwtFromHeader(req);
+
+		if (StringUtils.hasText(tokenValue)) {
+			try {
+				// 1. 토큰 검증 (만료되면 ExpiredJwtException 발생)
+				jwtUtil.validateToken(tokenValue);
+
+				// 로그아웃 토큰 사용 방지를 위한 블랙리스트 검사 로직 추가
+				// 1-1. Access Token의 JTI(JWT ID) 추출
+				String jti = jwtUtil.getJtiFromToken(tokenValue);
+
+				// 1-2. Redis 블랙리스트에서 해당 JTI 존재 여부 확인
+				if (redisService.isTokenBlacklisted(jti)) { // RedisService에 있는 isTokenBlacklisted 사용
+					log.error("블랙리스트에 등록된 토큰 사용 시도: {}", jti);
+					// SecurityException을 발생시켜 하단의 catch 블록으로 넘깁니다.
+					throw new SecurityException("Blacklisted Access Token");
+				}
+
+				// 2. Claim에서 사용자 정보 추출 및 SecurityContext 설정
+				Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+				setAuthentication(info.getSubject());
+
+			} catch (ExpiredJwtException e) {
+				log.warn("Access Token 만료: {} - 재발급 필요", e.getMessage());
+				handleSecurityException(res, ClientErrorCode.EXPIRED_TOKEN);
+				return;
+			} catch (SecurityException e) { // 블랙리스트 또는 유효하지 않은 토큰
+				log.error("블랙리스트 토큰 또는 유효하지 않은 토큰: {}", e.getMessage());
+				handleSecurityException(res, ClientErrorCode.BLACKLISTED_TOKEN);
+				return;
+			} catch (Exception e) {
+				log.error("JWT 검증 중 알 수 없는 오류 발생: {}", e.getMessage());
+				handleSecurityException(res, ClientErrorCode.INVALID_TOKEN);
+				return;
+			}
+		}
+
+		filterChain.doFilter(req, res);
+	}
+
+	/**
+	 * SecurityContext에 인증 정보 설정
+	 */
+	public void setAuthentication(String username) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+		Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
+			userDetails.getAuthorities());
+		context.setAuthentication(authentication);
+		SecurityContextHolder.setContext(context);
+	}
+
+	/**
+	 * 보안 관련 예외 발생 시 응답 처리 (401 UNAUTHORIZED)
+	 */
+	private void handleSecurityException(HttpServletResponse res, ClientErrorCode errorCode) throws IOException {
+		res.setStatus(errorCode.getHttpStatus().value());
+		res.setContentType("application/json;charset=UTF-8");
+		res.getWriter().write(new ObjectMapper().writeValueAsString(
+			ApiResponse.fail(errorCode.getCode(), errorCode.getMessage())
+		));
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/UserDetailsImpl.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/UserDetailsImpl.java
@@ -1,0 +1,68 @@
+package com.opportunity.deliveryservice.global.infrastructure.config.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.opportunity.deliveryservice.user.domain.entity.User;
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+
+public class UserDetailsImpl implements UserDetails {
+
+	private final User user;
+
+	public UserDetailsImpl(User user) {
+		this.user = user;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getUsername();
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	// 사용자의 권한 가져오고 authorities 추가
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		UserRoleEnum role = user.getRole();
+		String authority = role.getAuthority();
+
+		SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(simpleGrantedAuthority);
+
+		return authorities;
+	}
+
+	// 순서대로 계정 만료, 잠김, 비밀번호 만료, 활성화 상태를 반환
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/UserDetailsServiceImpl.java
@@ -1,0 +1,27 @@
+package com.opportunity.deliveryservice.global.infrastructure.config.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.opportunity.deliveryservice.user.domain.entity.User;
+import com.opportunity.deliveryservice.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	// 사용자 조회
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user = userRepository.findByUsername(username)
+			.orElseThrow(() -> new UsernameNotFoundException("해당 사용자를 찾을 수 없습니다! : " + username));
+
+		return new UserDetailsImpl(user);
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/WebSecurityConfig.java
@@ -1,0 +1,108 @@
+package com.opportunity.deliveryservice.global.infrastructure.config.security;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.opportunity.deliveryservice.global.infrastructure.jwt.JwtUtil;
+import com.opportunity.deliveryservice.global.infrastructure.redis.RedisService;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true) // @Secured(권한 별 접근 제어) 활성화
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+	private final JwtUtil jwtUtil;
+	private final UserDetailsServiceImpl userDetailsService;
+	private final AuthenticationConfiguration authenticationConfiguration;
+	private final RedisService redisService;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+		return configuration.getAuthenticationManager();
+	}
+
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+		JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, redisService);
+		filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+		return filter;
+	}
+
+	@Bean
+	public JwtAuthorizationFilter jwtAuthorizationFilter() {
+		return new JwtAuthorizationFilter(jwtUtil, userDetailsService, redisService);
+	}
+
+	@Bean
+	public RoleHierarchy roleHierarchy() {
+		// 권한 계층 구조 설정
+		return RoleHierarchyImpl.fromHierarchy("""
+			ROLE_MASTER > ROLE_MANAGER
+			ROLE_MANAGER > ROLE_OWNER
+			ROLE_MANAGER > ROLE_CUSTOMER
+			""");
+
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		// CSRF 설정
+		http.csrf((csrf) -> csrf.disable());
+
+		// 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
+		http.sessionManagement((sessionManagement) ->
+			sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+		);
+
+		http.authorizeHttpRequests((authorizeHttpRequests) ->
+			authorizeHttpRequests
+				.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+				.permitAll() // resources 접근 허용 설정
+				.requestMatchers("/")
+				.permitAll() // 메인 페이지 요청 허가
+				.requestMatchers("/v1/users/signup", "/v1/users/login")
+				.permitAll() // "/v1/users/sighup","/v1/users/login"로 시작하는 요청 모두 접근 허가
+				.anyRequest()
+				.authenticated() // 그 외 모든 요청 인증처리
+		);
+
+		http.formLogin((formLogin) ->
+			formLogin
+				.disable()
+		);
+
+		// http.formLogin((formLogin) ->
+		// 	formLogin
+		// 		.loginPage("/").permitAll()
+		// );
+
+		// 필터 관리(앞에있는 필터 먼저 실행)
+		http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+		http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/jwt/JwtUtil.java
@@ -1,0 +1,188 @@
+package com.opportunity.deliveryservice.global.infrastructure.jwt;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.opportunity.deliveryservice.global.infrastructure.redis.RedisService;
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String REFRESH_TOKEN_COOKIE_NAME = "RefreshToken";
+	public static final String AUTHORIZATION_KEY = "auth";
+	public static final String BEARER_PREFIX = "Bearer ";
+
+	private static final long ACCESS_TOKEN_TIME = 30 * 60 * 1000L; // 30분
+	private static final long REFRESH_TOKEN_TIME = 14 * 24 * 60 * 60 * 1000L; // 14일
+	private static final int REFRESH_TOKEN_COOKIE_MAX_AGE = 14 * 24 * 60 * 60; // HttpOnly 쿠키 만료 기간: 14일
+
+	@Value("${jwt.secret.key}")
+	private String secretKey;
+	private Key key;
+	private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+	private final RedisService redisService; // Blacklist, RT 관리를 위해 RedisService 주입
+
+	@PostConstruct
+	public void init() {
+		byte[] bytes = Base64.getDecoder().decode(secretKey);
+		key = Keys.hmacShaKeyFor(bytes);
+	}
+
+	/**
+	 * Access Token 생성 (30분)
+	 */
+	public String createAccessToken(String username, UserRoleEnum role) {
+		Date date = new Date();
+		String jti = UUID.randomUUID().toString(); // JTI (JWT ID) 추가
+
+		return BEARER_PREFIX +
+			Jwts.builder()
+				.setSubject(username)
+				.claim(AUTHORIZATION_KEY, role.getAuthority())
+				.claim("jti", jti) // Blacklist 관리를 위한 JTI
+				.setExpiration(new Date(date.getTime() + ACCESS_TOKEN_TIME))
+				.setIssuedAt(date)
+				.signWith(key, signatureAlgorithm)
+				.compact();
+	}
+
+	/**
+	 * Refresh Token 생성 (14일)
+	 */
+	public String createRefreshToken(String username, UserRoleEnum role) {
+		Date date = new Date();
+		String jti = UUID.randomUUID().toString(); // JTI (JWT ID) 추가
+
+		return Jwts.builder()
+			.setSubject(username)
+			.claim(AUTHORIZATION_KEY, role.getAuthority())
+			.claim("jti", jti)
+			.setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))
+			.setIssuedAt(date)
+			.signWith(key, signatureAlgorithm)
+			.compact();
+	}
+
+	/**
+	 * HttpServletRequest Header에서 Access Token 값 가져오기
+	 */
+	public static String getJwtFromHeader(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+		log.info("JwtUtil - Authorization Header Raw Value: {}", bearerToken);
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+
+	/**
+	 * Refresh Token을 HttpOnly 쿠키에 담아 반환
+	 */
+	public Cookie createRefreshTokenCookie(String refreshToken) {
+		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+		cookie.setHttpOnly(true); // HttpOnly 설정
+		// cookie.setSecure(true); // HTTPS 환경에서만 전송 (운영 환경 권장, 테스트 할 땐 비활성화)
+		cookie.setPath("/"); // 모든 경로에서 쿠키 접근 가능
+		cookie.setMaxAge(REFRESH_TOKEN_COOKIE_MAX_AGE); // 쿠키 만료 기간 14일
+		return cookie;
+	}
+
+	// HttpOnly쿠키 만료
+	public void deleteCookie(HttpServletResponse response, String cookieName) {
+		Cookie cookie = new Cookie(cookieName, null);
+		cookie.setMaxAge(0); // 즉시 만료
+		cookie.setPath("/");
+
+		// HttpOnly 설정 (Refresh Token과 같은 민감 정보는 항상 HttpOnly)
+		cookie.setHttpOnly(true);
+
+		// HTTPS 환경에서만 전송 (운영 환경 권장, 테스트 할 땐 비활성화)
+		// cookie.setSecure(true);
+
+		response.addCookie(cookie);
+	}
+
+	/**
+	 * 토큰 검증 (만료 여부, 서명 유효성 등)
+	 */
+	public boolean validateToken(String token) {
+		try {
+			// 서명 및 만료 검증
+			Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+
+			// 블랙리스트에 등록되어있는지 확인 (JTI 사용)
+			String jti = claims.get("jti", String.class);
+			if (redisService.isTokenBlacklisted(jti)) {
+				log.error("Blacklisted Token: {}", jti);
+				throw new SecurityException("Blacklisted Token");
+			}
+			return true;
+		} catch (SecurityException | MalformedJwtException | SignatureException e) {
+			log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+		} catch (ExpiredJwtException e) {
+			log.error("Expired JWT token, 만료된 JWT token 입니다.");
+			throw e; // 만료된 토큰은 재발급 로직을 위해 던짐
+		} catch (UnsupportedJwtException e) {
+			log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+		} catch (IllegalArgumentException e) {
+			log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+		} catch (Exception e) { // 블랙리스트 예외 처리
+			log.error("Token Validation Error: {}", e.getMessage());
+			throw new SecurityException("Invalid or Blacklisted Token");
+		}
+		return false;
+	}
+
+	/**
+	 * 토큰에서 사용자 정보(Claims) 추출
+	 */
+	public Claims getUserInfoFromToken(String token) {
+		try {
+			return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+		} catch (ExpiredJwtException e) {
+			// 만료된 토큰이라도 재발급/로그아웃 처리를 위해 Claim은 반환
+			return e.getClaims();
+		}
+	}
+
+	/**
+	 * 토큰에서 JTI(JWT ID) 추출
+	 */
+	public String getJtiFromToken(String token) {
+		return getUserInfoFromToken(token).get("jti", String.class);
+	}
+
+	/**
+	 * 토큰의 남은 만료 시간 (ms) 계산
+	 */
+	public long getExpirationRemainingTime(String token) {
+		Date expiration = getUserInfoFromToken(token).getExpiration();
+		return expiration.getTime() - new Date().getTime();
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/redis/RedisConfig.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/redis/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.opportunity.deliveryservice.global.infrastructure.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+// Redis 관련 설정
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Value("${spring.data.redis.password}")
+	private String password;
+
+	// Redis 연결 팩토리 설정(Redis 서버에 연결하기 위한 빈(Bean)을 생성)
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+		config.setPassword(password);
+		return new LettuceConnectionFactory(config);
+	}
+
+	// RedisTemplate 설정(key, value String으로 직렬화 / Redis DB와 연결하는 Bean을 생성)
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		// Key 직렬화
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		// Value 직렬화
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/redis/RedisService.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/redis/RedisService.java
@@ -1,0 +1,42 @@
+package com.opportunity.deliveryservice.global.infrastructure.redis;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	// Refresh Token 저장(Key: username, Value: RefreshToken / 평문으로 저장)
+	public void setRefreshToken(String username, String refreshToken, Duration expiration) {
+		redisTemplate.opsForValue().set(username, refreshToken, expiration);
+	}
+
+	// Refresh Token 조회
+	public String getRefreshToken(String username) {
+		return redisTemplate.opsForValue().get(username);
+	}
+
+	// Refresh Token 삭제 (로그아웃, 재발급 성공 시)
+	public void deleteRefreshToken(String username) {
+		redisTemplate.delete(username);
+	}
+
+	// Access / Refresh Token Blacklist 등록(Key: jti 값(UUID), Value: blacklist)
+	public void setBlacklist(String tokenKey, Duration expiration) {
+		redisTemplate.opsForValue().set(tokenKey, "blacklist", expiration);
+	}
+
+	// Blacklist 조회 (토큰이 폐기되었는지 확인)
+	public boolean isTokenBlacklisted(String tokenKey) {
+		return redisTemplate.hasKey(tokenKey);
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/application/service/AddressServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/application/service/AddressServiceV1.java
@@ -1,0 +1,100 @@
+package com.opportunity.deliveryservice.user.application.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.opportunity.deliveryservice.global.common.code.ClientErrorCode;
+import com.opportunity.deliveryservice.global.common.exception.OpptyException;
+import com.opportunity.deliveryservice.user.domain.entity.Address;
+import com.opportunity.deliveryservice.user.domain.entity.User;
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+import com.opportunity.deliveryservice.user.domain.repository.AddressRepository;
+import com.opportunity.deliveryservice.user.presentation.dto.request.AddressRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.response.AddressResponseDto;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AddressServiceV1 {
+
+	private final AddressRepository addressRepository;
+	private final EntityManager entityManager;
+
+	/**
+	 * 주소록 생성
+	 */
+	@Transactional
+	public AddressResponseDto createAddress(AddressRequestDto requestDto, User user) {
+		Address address = new Address(requestDto, user);
+
+		address = addressRepository.save(address);
+		return new AddressResponseDto(address);
+	}
+
+	/**
+	 * 주소록 수정
+	 */
+	@Transactional
+	public AddressResponseDto updateAddress(UUID addressId, AddressRequestDto requestDto, User currentUser) {
+		Address address = getAddressById(addressId);
+
+		// 권한 검증: 소유자 또는 MASTER 수정 가능
+		checkAuthority(address, currentUser);
+
+		address.update(requestDto);
+		return new AddressResponseDto(address);
+	}
+
+	/**
+	 * 주소록 삭제 (Soft Delete)
+	 */
+	@Transactional
+	public void deleteAddress(UUID addressId, User currentUser) {
+		Address address = getAddressById(addressId);
+
+		// 권한 검증: 소유자 또는 MASTER/MANAGER만 삭제 가능
+		checkAuthority(address, currentUser);
+
+		if (address.getDeletedAt() == null) {
+			// Soft Delete 실행 (@SQLDelete에 의해 update 쿼리 실행)
+			addressRepository.delete(address);
+		} else {
+			throw new OpptyException(ClientErrorCode.RESOURCE_NOT_FOUND);
+		}
+	}
+
+	/**
+	 * 주소록 엔티티 조회
+	 */
+	private Address getAddressById(UUID addressId) {
+		// @SQLRestriction에 의해 deletedAt IS NULL 인 데이터만 조회됨
+		return addressRepository.findById(addressId).orElseThrow(() ->
+			new OpptyException(ClientErrorCode.ADDRESS_NOT_FOUND)
+		);
+	}
+
+	/**
+	 * 주소록 수정/삭제 권한 검증 로직
+	 */
+	private void checkAuthority(Address address, User currentUser) {
+		User targetUser = address.getUser(); // 주소록 소유자
+
+		// 1. 소유자(Owner) 검증: 본인이라면 권한에 관계없이 즉시 통과
+		if (targetUser.getId().equals(currentUser.getId())) {
+			return;
+		}
+
+		// 2. MASTER 권한 검증: 현재 사용자가 MASTER라면 타인의 주소록이라도 통과
+		if (currentUser.getRole() == UserRoleEnum.MASTER) {
+			return;
+		}
+
+		// 3. 위의 두 조건을 통과하지 못한 경우 (MANAGER, CUSTOMER 등이 타인의 주소록에 접근)
+		throw new OpptyException(ClientErrorCode.FORBIDDEN);
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
@@ -88,8 +88,8 @@ public class UserServiceV1 {
 	@Transactional
 	public void logout(String accessToken, String refreshToken) {
 
-		// Access Token 유효성 검사 (만료 여부, 서명 등)
-		// Refresh Token 유효성 검사 (만료 여부, 서명 등)
+		// Access Token 유효성 검사 (만료 여부, 서명 등등)
+		// Refresh Token 유효성 검사 (만료 여부, 서명 등등)
 		try {
 			jwtUtil.validateToken(accessToken); // 여기서 블랙리스트 및 만료 검사
 			jwtUtil.validateToken(refreshToken); // 여기서 블랙리스트 및 만료 검사

--- a/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
@@ -88,7 +88,7 @@ public class UserServiceV1 {
 	@Transactional
 	public void logout(String accessToken, String refreshToken) {
 
-		// Access Toㅇken 유효성 검사 (만료 여부, 서명 등)
+		// Access Token 유효성 검사 (만료 여부, 서명 등)
 		// Refresh Token 유효성 검사 (만료 여부, 서명 등)
 		try {
 			jwtUtil.validateToken(accessToken); // 여기서 블랙리스트 및 만료 검사

--- a/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
@@ -1,0 +1,276 @@
+package com.opportunity.deliveryservice.user.application.service;
+
+import java.time.Duration;
+
+import org.hibernate.Filter;
+import org.hibernate.Session;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.opportunity.deliveryservice.global.common.code.ClientErrorCode;
+import com.opportunity.deliveryservice.global.common.exception.OpptyException;
+import com.opportunity.deliveryservice.global.infrastructure.jwt.JwtUtil;
+import com.opportunity.deliveryservice.global.infrastructure.redis.RedisService;
+import com.opportunity.deliveryservice.user.domain.entity.User;
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+import com.opportunity.deliveryservice.user.domain.repository.UserRepository;
+import com.opportunity.deliveryservice.user.presentation.dto.request.AdminSearchUserRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserRoleUpdateRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserSignupRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserUpdateRequestDto;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.persistence.EntityManager;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceV1 {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwtUtil;
+	private final RedisService redisService;
+	private final EntityManager entityManager;
+
+	@Value("${jwt.admin.token}")
+	private String ADMIN_TOKEN;
+
+	/**
+	 * 회원가입
+	 */
+	@Transactional
+	public void signup(UserSignupRequestDto requestDto) {
+		// 중복 검사
+		if (userRepository.existsByUsername(requestDto.getUsername())) {
+			throw new OpptyException(ClientErrorCode.DUPLICATE_USERNAME);
+		}
+		if (userRepository.existsByEmail((requestDto.getEmail()))) {
+			throw new OpptyException(ClientErrorCode.DUPLICATE_EMAIL);
+		}
+
+		// 권한 검사 (MASTER 권한은 인증키 필요)
+		UserRoleEnum role = requestDto.getRole();
+		if (role == UserRoleEnum.MASTER) {
+			if (!ADMIN_TOKEN.equals(requestDto.getRoleAuthKey())) {
+				throw new OpptyException(ClientErrorCode.INVALID_ADMIN_KEY);
+			}
+		}
+
+		// 비밀번호 암호화
+		String rawPassword = requestDto.getPassword();
+		String encodedPassword = passwordEncoder.encode(rawPassword);
+
+		// MANAGER는 MASTER가 권한 부여해야 하므로 회원가입 X
+		if (role != UserRoleEnum.MANAGER || !ADMIN_TOKEN.equals(requestDto.getRoleAuthKey())) {
+			// 사용자 등록: MANAGER는 MASTER가 권한 부여해줘야 가능
+
+			User user = new User(requestDto, encodedPassword);
+
+			userRepository.save(user);
+		} else {
+			throw new OpptyException(ClientErrorCode.INVALID_ADMIN_KEY);
+		}
+	}
+
+	/**
+	 * 로그아웃 (AT/RT 블랙리스트 등록 및 Redis RT 삭제)
+	 */
+	@Transactional
+	public void logout(String accessToken, String refreshToken) {
+
+		// Access Toㅇken 유효성 검사 (만료 여부, 서명 등)
+		// Refresh Token 유효성 검사 (만료 여부, 서명 등)
+		try {
+			jwtUtil.validateToken(accessToken); // 여기서 블랙리스트 및 만료 검사
+			jwtUtil.validateToken(refreshToken); // 여기서 블랙리스트 및 만료 검사
+		} catch (ExpiredJwtException e) {
+			throw new OpptyException(ClientErrorCode.EXPIRED_TOKEN);
+		} catch (SecurityException e) {
+			throw new OpptyException(ClientErrorCode.BLACKLISTED_TOKEN);
+		} catch (Exception e) {
+			throw new OpptyException(ClientErrorCode.INVALID_TOKEN);
+		}
+
+		// 1. Access Token Blacklist 등록 (AT의 JTI 사용)
+		String atJti = jwtUtil.getJtiFromToken(accessToken);
+		long atExpirationMs = jwtUtil.getExpirationRemainingTime(accessToken);
+		if (atExpirationMs > 0) {
+			redisService.setBlacklist(atJti, Duration.ofMillis(atExpirationMs));
+		}
+
+		// 2. Refresh Token Blacklist 등록 (RT의 JTI 사용)
+		String rtJti = jwtUtil.getJtiFromToken(refreshToken);
+		long rtExpirationMs = jwtUtil.getExpirationRemainingTime(refreshToken);
+		if (rtExpirationMs > 0) {
+			redisService.setBlacklist(rtJti, Duration.ofMillis(rtExpirationMs));
+		}
+
+		// 3. Redis에 저장된 Refresh Token 삭제 & HttpOnly 쿠키 만료
+		Claims rtClaims = jwtUtil.getUserInfoFromToken(refreshToken); // username으로 삭제
+		redisService.deleteRefreshToken(rtClaims.getSubject());
+	}
+
+	/**
+	 * 토큰 재발급 (RT 유효성 검사 -> 기존 토큰 폐기 -> 새 토큰 발급 및 저장)
+	 */
+	@Transactional
+	public void reissueToken(String accessToken, String refreshToken, HttpServletResponse response) {
+		// 1. Refresh Token 유효성 검사 (만료 여부, 서명 등)
+		try {
+			jwtUtil.validateToken(refreshToken); // 여기서 블랙리스트 및 만료 검사
+		} catch (ExpiredJwtException e) {
+			throw new OpptyException(ClientErrorCode.EXPIRED_TOKEN);
+		} catch (SecurityException e) {
+			throw new OpptyException(ClientErrorCode.BLACKLISTED_TOKEN);
+		} catch (Exception e) {
+			throw new OpptyException(ClientErrorCode.INVALID_TOKEN);
+		}
+
+		// 2. Refresh Token Claims 추출 및 Redis 일치 확인
+		Claims rtClaims = jwtUtil.getUserInfoFromToken(refreshToken);
+		String username = rtClaims.getSubject();
+		String storedRt = redisService.getRefreshToken(username);
+
+		if (storedRt == null || !storedRt.equals(refreshToken)) {
+			throw new OpptyException(ClientErrorCode.BLACKLISTED_TOKEN);
+		}
+
+		// 3. 기존 AT/RT Blacklist 등록 및 Redis RT 삭제 (로그아웃 로직 재사용)
+		logout(accessToken, refreshToken);
+
+		// 4. 새로운 Access Token, Refresh Token 생성
+		UserRoleEnum role = UserRoleEnum.valueOf(rtClaims.get(JwtUtil.AUTHORIZATION_KEY, String.class).substring(5));
+		String newAccessToken = jwtUtil.createAccessToken(username, role);
+		String newRefreshToken = jwtUtil.createRefreshToken(username, role);
+
+		// 5. 새로운 토큰 응답 설정
+		response.addHeader(JwtUtil.AUTHORIZATION_HEADER, newAccessToken);
+		response.addCookie(jwtUtil.createRefreshTokenCookie(newRefreshToken));
+
+		// 6. 새로운 Refresh Token Redis에 저장
+		long newRtExpirationMs = jwtUtil.getExpirationRemainingTime(newRefreshToken);
+		redisService.setRefreshToken(username, newRefreshToken, Duration.ofMillis(newRtExpirationMs));
+	}
+
+	/**
+	 * 유저 조회
+	 */
+	public User findUserById(Long userId) {
+		return userRepository.findById(userId).orElseThrow(() ->
+			new OpptyException(ClientErrorCode.USER_NOT_FOUND)
+		);
+	}
+
+	/**
+	 * 회원 정보 수정
+	 */
+	@Transactional
+	public void updateUser(Long userId, UserUpdateRequestDto requestDto, User currentUser) {
+		User user = findUserById(userId);
+
+		// 1. 권한 검증: 본인만 수정 가능
+		if (!user.getId().equals(currentUser.getId())) {
+			throw new OpptyException(ClientErrorCode.FORBIDDEN);
+		}
+
+		if (currentUser.getRole().equals(UserRoleEnum.MASTER) || currentUser.getRole().equals(UserRoleEnum.MANAGER)) {
+
+		}
+		String encodedNewPassword = null;
+		if (requestDto.getNewPassword() != null) {
+			// 기존 비밀번호 확인
+			if (!passwordEncoder.matches(requestDto.getOldPassword(), user.getPassword())) {
+				throw new OpptyException(ClientErrorCode.INVALID_PASSWORD);
+			}
+			encodedNewPassword = passwordEncoder.encode(requestDto.getNewPassword());
+		}
+
+		// 2. 정보 업데이트
+		user.update(requestDto, encodedNewPassword);
+	}
+
+	/**
+	 * 회원 탈퇴 (Soft Delete)
+	 */
+	@Transactional
+	public void deleteUser(Long userId, String password, User currentUser) {
+		User user = findUserById(userId);
+
+		// 1. 권한 검증: 본인만 탈퇴 가능
+		if (!user.getId().equals(currentUser.getId())) {
+			throw new OpptyException(ClientErrorCode.FORBIDDEN);
+		}
+
+		// 2. 비밀번호 확인
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw new OpptyException(ClientErrorCode.INVALID_PASSWORD);
+		}
+
+		// 3. Soft Delete 실행 (@SQLDelete에 의해 deleted_at 업데이트)
+		userRepository.delete(user);
+	}
+
+	/**
+	 * 관리자 전용 사용자 조회 (검색, 페이징, 정렬, Soft Delete 포함)
+	 */
+	public Page<User> searchUsersByAdmin(AdminSearchUserRequestDto requestDto) {
+
+		Session session = entityManager.unwrap(Session.class);
+
+		Filter userFilter = session.enableFilter("deletedUserFilter");
+		userFilter.setParameter("isDeleted", true);
+
+		Filter addressFilter = session.enableFilter("deletedAddressFilter");
+		addressFilter.setParameter("isDeleted", true);
+		// 1. 필터 활성화 및 파라미터 설정
+		// session.enableFilter("softDeleteFilter")
+		// 	.setParameter("isDeleted", true); // isDeleted=true 시 deleted_at IS NULL 조건 무시
+
+		Pageable pageable = requestDto.toPageable();
+		String keyword = requestDto.getKeyword();
+		UserRoleEnum role = requestDto.getRole();
+
+		try {
+			// 키워드에 와일드카드 문자열 "%"를 추가하여 JPQL LIKE 연산에 전달
+			if (keyword != null) {
+				keyword = "%" + keyword + "%";
+			}
+
+			// 모든 데이터를 조회하는 Custom Repository 메서드 사용
+			return userRepository.findUsersByAdminCriteria(role, keyword, pageable);
+		} finally {
+			// 3. 필터 비활성화
+			session.disableFilter("deletedUserFilter");
+			session.disableFilter("deletedAddressFilter");
+		}
+
+	}
+
+	/**
+	 * 관리자에 의한 권한 부여/변경 (MASTER만 가능)
+	 */
+	@Transactional
+	public void updateRole(Long targetUserId, UserRoleUpdateRequestDto requestDto, User currentUser) {
+		// 1. 현재 사용자(Master)의 권한 확인 (Master만 권한 변경 가능)
+		if (currentUser.getRole() != UserRoleEnum.MASTER) {
+			throw new OpptyException(ClientErrorCode.UNAUTHORIZED_ROLE_CHANGE);
+		}
+
+		User targetUser = userRepository.findById(targetUserId).orElseThrow(() ->
+			new OpptyException(ClientErrorCode.USER_NOT_FOUND)
+		);
+
+		// 2. 권한 변경
+		targetUser.updateRole(requestDto.getNewRole());
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/domain/entity/Address.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/domain/entity/Address.java
@@ -1,0 +1,76 @@
+package com.opportunity.deliveryservice.user.domain.entity;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+import org.hibernate.annotations.SQLDelete;
+
+import com.opportunity.deliveryservice.global.common.entity.BaseEntity;
+import com.opportunity.deliveryservice.user.presentation.dto.request.AddressRequestDto;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// 필터 조건: isDeleted가 true일 경우 'deleted_at IS NULL' 조건을 무시함
+// @Filter(name = "softDeleteFilter", condition = "deleted_at IS NULL OR  :isDeleted = true")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "p_user_address")
+// 삭제 처리 하지않고 update(soft delete) 처리
+@SQLDelete(sql = "update p_user_address set deleted_at = NOW() where id = ?")
+@FilterDef(name = "deletedAddressFilter", parameters = @ParamDef(name = "isDeleted", type = Boolean.class))
+@Filter(name = "deletedAddressFilter", condition = "deleted_at IS NULL OR :isDeleted = true")
+
+public class Address extends BaseEntity {
+
+	@Id // 기본키 & 자동생성: UUID
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID id;
+
+	@Column
+	private String city;
+
+	@Column
+	private String gu;
+
+	@Column(name = "detail_address")
+	private String detailAddress;
+
+	@Column
+	private String nickname;
+
+	@ManyToOne(fetch = FetchType.LAZY) // 외래키
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	public Address(AddressRequestDto requestDto, User user) {
+		this.city = requestDto.getCity();
+		this.gu = requestDto.getGu();
+		this.detailAddress = requestDto.getDetailAddress();
+		this.nickname = requestDto.getNickname();
+		this.user = user;
+	}
+
+	// 주소록 수정
+	public void update(AddressRequestDto requestDto) {
+		this.city = requestDto.getCity();
+		this.gu = requestDto.getGu();
+		this.detailAddress = requestDto.getDetailAddress();
+		this.nickname = requestDto.getNickname();
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/domain/entity/User.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/domain/entity/User.java
@@ -1,0 +1,86 @@
+package com.opportunity.deliveryservice.user.domain.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+import org.hibernate.annotations.SQLDelete;
+
+import com.opportunity.deliveryservice.global.common.entity.BaseEntity;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserSignupRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserUpdateRequestDto;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 기본 생성자 접근 수준을 PROTECTED로 설정
+// SQL Delete문을 실행하지않고(삭제 처리 하지않고) Update(soft delete)문 실행
+
+@SQLDelete(sql = "UPDATE p_users SET deleted_at = NOW() WHERE id = ?")
+@FilterDef(name = "deletedUserFilter", parameters = @ParamDef(name = "isDeleted", type = Boolean.class))
+@Filter(name = "deletedUserFilter", condition = "deleted_at IS NULL OR :isDeleted = true")
+
+// 필터 정의: "softDeleteFilter"라는 이름과 isDeleted 매개변수 정의
+@Table(name = "p_users")
+@Entity
+public class User extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String username;
+
+	@Column(nullable = false, unique = true)
+	private String email;
+
+	@Column(nullable = false)
+	private String password;
+
+	@Column(nullable = false)
+	@Enumerated(value = EnumType.STRING)
+	private UserRoleEnum role;
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Filter(name = "deletedAddressFilter", condition = "deleted_at IS NULL OR :isDeleted = true")
+	private List<Address> addressList = new ArrayList<>();
+
+	public User(UserSignupRequestDto requestDto, String encodedPassword) {
+		this.username = requestDto.getUsername();
+		this.email = requestDto.getEmail();
+		this.password = encodedPassword;
+		this.role = requestDto.getRole();
+	}
+
+	// 회원 정보 수정
+	public void update(UserUpdateRequestDto requestDto, String encodedPassword) {
+		if (requestDto.getEmail() != null) {
+			this.email = requestDto.getEmail();
+		}
+		if (encodedPassword != null) {
+			this.password = encodedPassword;
+		}
+	}
+
+	// 관리자(MASTER)에 의한 권한 변경
+	public void updateRole(UserRoleEnum role) {
+		this.role = role;
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/domain/entity/UserRoleEnum.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/domain/entity/UserRoleEnum.java
@@ -1,0 +1,26 @@
+package com.opportunity.deliveryservice.user.domain.entity;
+
+public enum UserRoleEnum {
+	MASTER(Authority.MASTER), // 최종 관리자
+	MANAGER(Authority.MANAGER), // 중간 관리자
+	OWNER(Authority.OWNER), // 가게 사장
+	CUSTOMER(Authority.CUSTOMER); // 고객
+
+	private final String authority;
+
+	UserRoleEnum(String authority) {
+		this.authority = authority;
+	}
+
+	public String getAuthority() {
+		return this.authority;
+	}
+
+	public static class Authority {
+		public static final String MASTER = "ROLE_MASTER";
+		public static final String MANAGER = "ROLE_MANAGER";
+		public static final String OWNER = "ROLE_OWNER";
+		public static final String CUSTOMER = "ROLE_CUSTOMER";
+	}
+}
+

--- a/src/main/java/com/opportunity/deliveryservice/user/domain/repository/AddressRepository.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/domain/repository/AddressRepository.java
@@ -1,0 +1,11 @@
+package com.opportunity.deliveryservice.user.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.opportunity.deliveryservice.user.domain.entity.Address;
+
+// deletedAt IS NULL 인 데이터만 조회됨
+public interface AddressRepository extends JpaRepository<Address, UUID> {
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/domain/repository/UserRepository.java
@@ -1,0 +1,39 @@
+package com.opportunity.deliveryservice.user.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.opportunity.deliveryservice.user.domain.entity.User;
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	boolean existsByUsername(String username);
+
+	boolean existsByEmail(String email);
+
+	Optional<User> findByUsername(String username);
+
+
+	// 관리자 전용 조회(Soft Delete 포함) - JPQL로 명시적 구현
+	// keyword로 username 또는 email 검색
+	@Query(value = """
+		SELECT DISTINCT u 
+		FROM User u 
+		JOIN FETCH u.addressList
+		WHERE 
+		    (:keyword IS NULL OR u.username LIKE :keyword OR u.email LIKE :keyword)
+		    AND (:role IS NULL OR u.role = :role)
+		ORDER BY u.createdAt DESC
+		""")
+	Page<User> findUsersByAdminCriteria(
+		@Param("role") UserRoleEnum role,
+		@Param("keyword") String keyword, // ServiceV1에서 이미 %를 붙였으므로 여기서는 :keyword로만 사용
+		Pageable pageable
+	);
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/controller/UserControllerV1.java
@@ -1,0 +1,237 @@
+package com.opportunity.deliveryservice.user.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.opportunity.deliveryservice.global.common.code.ClientErrorCode;
+import com.opportunity.deliveryservice.global.common.exception.OpptyException;
+import com.opportunity.deliveryservice.global.common.response.ApiResponse;
+import com.opportunity.deliveryservice.global.infrastructure.config.security.UserDetailsImpl;
+import com.opportunity.deliveryservice.global.infrastructure.jwt.JwtUtil;
+import com.opportunity.deliveryservice.user.application.service.AddressServiceV1;
+import com.opportunity.deliveryservice.user.application.service.UserServiceV1;
+import com.opportunity.deliveryservice.user.domain.entity.User;
+import com.opportunity.deliveryservice.user.presentation.dto.request.AddressRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.AdminSearchUserRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserDeleteRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserRoleUpdateRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserSignupRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.request.UserUpdateRequestDto;
+import com.opportunity.deliveryservice.user.presentation.dto.response.AddressResponseDto;
+import com.opportunity.deliveryservice.user.presentation.dto.response.UserResponseDto;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/users")
+@RequiredArgsConstructor
+public class UserControllerV1 {
+
+	private final UserServiceV1 userService;
+	private final AddressServiceV1 addressService;
+	private final JwtUtil jwtUtil;
+
+	/**
+	 * 회원가입 API
+	 */
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody UserSignupRequestDto requestDto) {
+		userService.signup(requestDto);
+		return ResponseEntity.ok(ApiResponse.successNoData("201 Created", "회원가입에 성공했습니다!"));
+	}
+
+	/**
+	 * 로그인 API
+	 * JwtAuthenticationFilter가 로그인 성공 or 실패 시 로직을 가지고 있음
+	 * -> 로그인을 처리(Postman으로 테스트 성공)
+	 */
+
+	/**
+	 * 로그아웃 API
+	 * JWT Filter는 로그인 시에만 작동하므로, 로그아웃 시 토큰 폐기는 Controller/Service에서 수동 처리
+	 */
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Void>> logout(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@CookieValue(value = JwtUtil.REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		// JTI를 추출하기 위한 Access Token 유효성 검사
+		String accessToken = JwtUtil.getJwtFromHeader(request);
+
+		if (!StringUtils.hasText(accessToken)) {
+			// Access Token이 없으면 인증되지 않은 요청
+			throw new OpptyException(ClientErrorCode.UNAUTHORIZED);
+		}
+
+		// 2. Refresh Token 유효성 검사
+		if (!StringUtils.hasText(refreshToken)) {
+			// Refresh Token이 없으면 무효화 처리가 불가능
+			throw new OpptyException(ClientErrorCode.INVALID_TOKEN);
+		}
+
+		// 3. 로그아웃 (AT/RT 블랙리스트 등록 및 Redis RT 삭제)
+		userService.logout(accessToken, refreshToken);
+
+		// 4. HttpOnly 쿠키 삭제
+		jwtUtil.deleteCookie(response, JwtUtil.REFRESH_TOKEN_COOKIE_NAME);
+
+		return ResponseEntity.ok(ApiResponse.successNoData("200 OK", "로그아웃에 성공했습니다"));
+	}
+
+	/**
+	 * 토큰 재발급 API
+	 * Refresh Token (Cookie)과 만료된 Access Token (Header)을 사용하여 새 토큰을 발급합니다.
+	 */
+	@PostMapping("/reissue")
+	public ResponseEntity<ApiResponse<Void>> reissue(
+		@CookieValue(value = JwtUtil.REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		// 만료되었지만 JTI를 추출하기 위한 Access Token 유효성 검사
+		String expiredAccessToken = JwtUtil.getJwtFromHeader(request);
+
+		if (!StringUtils.hasText(expiredAccessToken)) {
+			// Access Token가 없으면 재발급 요청 자체가 성립하지 않음
+			throw new OpptyException(ClientErrorCode.UNAUTHORIZED);
+		}
+		if (!StringUtils.hasText(refreshToken)) {
+			// Refresh Token 쿠키가 없으면 재발급 불가
+			throw new OpptyException(ClientErrorCode.INVALID_TOKEN);
+		}
+
+		userService.reissueToken(expiredAccessToken, refreshToken, response);
+
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
+
+	/**
+	 * 마이페이지: 자신의 유저 정보 조회 (주소록 포함)
+	 */
+	@GetMapping("/me")
+	public ResponseEntity<ApiResponse<UserResponseDto>> getMyProfile(
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		User user = userService.findUserById(userDetails.getUser().getId());
+		return ResponseEntity.ok(ApiResponse.success(new UserResponseDto(user)));
+	}
+
+	/**
+	 * 회원 정보 수정
+	 */
+	@PutMapping("/me")
+	public ResponseEntity<ApiResponse<Void>> updateProfile(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@Valid @RequestBody UserUpdateRequestDto requestDto
+	) {
+		userService.updateUser(userDetails.getUser().getId(), requestDto, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.successNoData("200 OK", "회원정보 수정에 성공했습니다!"));
+	}
+
+	/**
+	 * 회원 탈퇴 (Soft Delete)
+	 */
+	@DeleteMapping("/me")
+	public ResponseEntity<ApiResponse<Void>> deleteUser(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@RequestBody UserDeleteRequestDto requestDto
+	) {
+		userService.deleteUser(userDetails.getUser().getId(), requestDto.getPassword(), userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.successNoData("200 OK", "성공적으로 회원탈퇴되었습니다!"));
+	}
+
+	// --- 주소록 (Address) CRUD ---
+
+	/**
+	 * 주소록 생성
+	 */
+	@PostMapping("/addresses")
+	public ResponseEntity<ApiResponse<AddressResponseDto>> createAddress(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@Valid @RequestBody AddressRequestDto requestDto
+	) {
+		addressService.createAddress(requestDto, userDetails.getUser());
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponse.successNoData("201 Created", "”주소록 등록에 성공했습니다!”"));
+	}
+
+	/**
+	 * 주소록 수정
+	 */
+	@PutMapping("/addresses/{addressId}")
+	public ResponseEntity<ApiResponse<AddressResponseDto>> updateAddress(
+		@PathVariable UUID addressId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@Valid @RequestBody AddressRequestDto requestDto
+	) {
+		addressService.updateAddress(addressId, requestDto, userDetails.getUser());
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.successNoData("200 OK", "”주소록 수정에 성공했습니다!”"));
+	}
+
+	/**
+	 * 주소록 삭제 (Soft Delete)
+	 */
+	@DeleteMapping("/addresses/{addressId}")
+	public ResponseEntity<ApiResponse<Void>> deleteAddress(
+		@PathVariable UUID addressId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		addressService.deleteAddress(addressId, userDetails.getUser());
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponse.successNoData("200 OK", "”주소록 삭제가 완료되었습니다!”"));
+	}
+
+	// --- 관리자 전용 기능 (Admin) ---
+
+	/**
+	 * 관리자 전용: 모든 사용자 정보 조회 (Search/Paging/Sort)
+	 * MASTER/MANAGER 권한만 접근 가능
+	 */
+	@Secured("ROLE_MASTER") // 권한이 MASTER만 접근 가능
+	@GetMapping("/admin")
+	public ResponseEntity<ApiResponse<Page<UserResponseDto>>> searchUsers(
+		AdminSearchUserRequestDto requestDto // @RequestParam 파라미터가 DTO에 자동으로 바인딩
+	) {
+		Page<User> userPage = userService.searchUsersByAdmin(requestDto);
+
+		// Entity Page를 DTO Page로 변환 (주소록도 포함)
+		Page<UserResponseDto> responsePage = userPage.map(UserResponseDto::new);
+
+		return ResponseEntity.ok(ApiResponse.success(responsePage));
+	}
+
+	/**
+	 * 관리자 전용: 권한 변경 (MASTER 권한만 가능)
+	 */
+	@Secured("ROLE_MASTER") // 권한이 MASTER만 접근 가능
+	@PatchMapping("/admin/{userId}/role")
+	public ResponseEntity<ApiResponse<Void>> updateRole(
+		@PathVariable Long userId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@Valid @RequestBody UserRoleUpdateRequestDto requestDto
+	) {
+		// MASTER 권한 검증은 Service에서 수행
+		userService.updateRole(userId, requestDto, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.successNoData("200 OK", "권한부여에 성공했습니다!"));
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/AddressRequestDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/AddressRequestDto.java
@@ -1,0 +1,19 @@
+package com.opportunity.deliveryservice.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AddressRequestDto {
+	@NotBlank(message = "도시를 입력해주세요.")
+	private String city;
+
+	@NotBlank(message = "구를 입력해주세요.")
+	private String gu;
+
+	@NotBlank(message = "상세 주소를 입력해주세요.")
+	private String detailAddress;
+
+	@NotBlank(message = "주소 별명을 입력해주세요.")
+	private String nickname;
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/AdminSearchUserRequestDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/AdminSearchUserRequestDto.java
@@ -1,0 +1,45 @@
+package com.opportunity.deliveryservice.user.presentation.dto.request;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
+
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminSearchUserRequestDto {
+
+	private String searchType; // username, email 등
+	private String keyword;
+	private UserRoleEnum role;
+
+	private int page = 1;
+	private int size = 10;
+	private String sortBy = "createdAt";
+	private boolean isAsc = false;
+
+	/**
+	 * Pageable 객체 생성 및 페이지 크기 제한 규칙 적용
+	 */
+	public Pageable toPageable() {
+		// 요구사항: 10건, 30건, 50건 외의 건수는 10건으로 고정
+		int fixedSize = switch (size) {
+			case 30 -> 30;
+			case 50 -> 50;
+			default -> 10;
+		};
+
+		String actualSortBy = StringUtils.hasText(sortBy) ? sortBy : "createdAt";
+
+		Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+		Sort sort = Sort.by(direction, actualSortBy);
+
+		// Pageable은 0부터 시작하므로 page - 1
+		return PageRequest.of(page > 0 ? page - 1 : 0, fixedSize, sort);
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserDeleteRequestDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserDeleteRequestDto.java
@@ -1,0 +1,8 @@
+package com.opportunity.deliveryservice.user.presentation.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserDeleteRequestDto {
+	private String password;
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserLoginRequestDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserLoginRequestDto.java
@@ -1,0 +1,13 @@
+package com.opportunity.deliveryservice.user.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UserLoginRequestDto {
+	@NotBlank(message = "아이디를 입력해주세요.")
+	private String username;
+
+	@NotBlank(message = "비밀번호를 입력해주세요.")
+	private String password;
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserRoleUpdateRequestDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserRoleUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.opportunity.deliveryservice.user.presentation.dto.request;
+
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class UserRoleUpdateRequestDto {
+	@NotNull(message = "변경할 권한을 반드시 입력해주세요.")
+	private UserRoleEnum newRole;
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserSignupRequestDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserSignupRequestDto.java
@@ -1,0 +1,27 @@
+package com.opportunity.deliveryservice.user.presentation.dto.request;
+
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class UserSignupRequestDto {
+	@Pattern(regexp = "^[a-z0-9]{4,10}$", message = "아이디는 4~10자의 소문자와 숫자로만 구성되어야 합니다.")
+	@NotBlank
+	private String username;
+
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$", message = "비밀번호는 8~15자의 대소문자, 숫자, 특수문자로 구성되어야 합니다.")
+	@NotBlank
+	private String password;
+
+	@Email(message = "유효하지 않은 이메일 형식입니다.")
+	@NotBlank
+	private String email;
+
+	private UserRoleEnum role = UserRoleEnum.CUSTOMER; // 기본권한 CUSTOMER
+
+	private String roleAuthKey; // MASTER 권한 부여 시 사용할 인증 키
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/request/UserUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package com.opportunity.deliveryservice.user.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class UserUpdateRequestDto {
+	private String oldPassword;
+
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
+		message = "비밀번호는 8~15자의 대소문자, 숫자, 특수문자로 구성되어야 합니다.")
+	private String newPassword;
+
+	@Email(message = "유효하지 않은 이메일 형식입니다.")
+	private String email;
+}

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/response/AddressResponseDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/response/AddressResponseDto.java
@@ -1,0 +1,32 @@
+package com.opportunity.deliveryservice.user.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.opportunity.deliveryservice.user.domain.entity.Address;
+
+import lombok.Getter;
+
+@Getter
+public class AddressResponseDto {
+	private UUID id;
+	private String city;
+	private String gu;
+	private String detailAddress;
+	private String nickname;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private LocalDateTime deletedAt;
+
+	public AddressResponseDto(Address address) {
+		this.id = address.getId();
+		this.city = address.getCity();
+		this.gu = address.getGu();
+		this.detailAddress = address.getDetailAddress();
+		this.nickname = address.getNickname();
+		this.createdAt = address.getCreatedAt();
+		this.updatedAt = address.getUpdatedAt();
+		this.deletedAt = address.getDeletedAt();
+	}
+}
+

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/response/UserResponseDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/response/UserResponseDto.java
@@ -1,0 +1,36 @@
+package com.opportunity.deliveryservice.user.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.opportunity.deliveryservice.user.domain.entity.User;
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+
+import lombok.Getter;
+
+@Getter
+public class UserResponseDto {
+	private Long id;
+	private String username;
+	private String email;
+	private UserRoleEnum role;
+	private LocalDateTime createdAt;
+	private LocalDateTime deletedAt;
+	private List<AddressResponseDto> addressList;
+
+	public UserResponseDto(User user) {
+		this.id = user.getId();
+		this.username = user.getUsername();
+		this.email = user.getEmail();
+		this.role = user.getRole();
+		this.createdAt = user.getCreatedAt();
+		this.deletedAt = user.getDeletedAt();
+
+		// Soft Delete 되지 않은 주소만 필터링하여 반환
+		this.addressList = user.getAddressList().stream()
+			.filter(address -> address.getDeletedAt() == null)
+			.map(AddressResponseDto::new)
+			.collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
🚩 관련 이슈

- 현재 Address의 Soft Delete된 데이터가 조회되지않는 현상이 발생하고있습니다.
- DeliveryServiceApplication의 @EnableJpaAuditing 어노테이션을 제거했습니다.(에러 해결)


📋 구현 기능 명세

- 회원 관련 기능
- 회원가입, 로그인, 로그아웃, 회원탈퇴, 마이페이지(주소록까지 포함해서 조회)
- 주소록 생성, 수정, 삭제
- 관리자 전용 조회(soft delete 포함 전체 유저 정보 조회)
- 권한 부여
- Access Token(Header), Refresh Token(HttpOnly, Redis) 및 블랙리스트
- 토큰 재발급(reissue)


📌 PR Point

- 수정할 코드가 있는지

- 이해가 잘 가는지

- 잘못된 부분이 있는지