### PR TITLE
[#17] fix: Soft Delete 조회되도록 수정 & 회원탈퇴한 유저의 로그인 실패하도록 수정

### DIFF
--- a/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/opportunity/deliveryservice/global/infrastructure/config/security/UserDetailsServiceImpl.java
@@ -19,7 +19,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 	// 사용자 조회
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		User user = userRepository.findByUsername(username)
+		User user = userRepository.findByUsernameAndDeletedAtIsNull(username)
 			.orElseThrow(() -> new UsernameNotFoundException("해당 사용자를 찾을 수 없습니다! : " + username));
 
 		return new UserDetailsImpl(user);

--- a/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
@@ -244,8 +244,7 @@ public class UserServiceV1 {
 				keyword = "%" + keyword + "%";
 			}
 			// 모든 데이터를 조회하는 Custom Repository 메서드 사용
-			Page<User> userPage = userRepository.findUsersByAdminCriteria(role, keyword, pageable);
-			return userPage;
+			return	userRepository.findUsersByAdminCriteria(role, keyword, pageable);
 		} finally {
 			// 필터 비활성화
 			session.disableFilter("deletedUserFilter");

--- a/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
@@ -189,9 +189,6 @@ public class UserServiceV1 {
 			throw new OpptyException(ClientErrorCode.FORBIDDEN);
 		}
 
-		if (currentUser.getRole().equals(UserRoleEnum.MASTER) || currentUser.getRole().equals(UserRoleEnum.MANAGER)) {
-
-		}
 		String encodedNewPassword = null;
 		if (requestDto.getNewPassword() != null) {
 			// 기존 비밀번호 확인

--- a/src/main/java/com/opportunity/deliveryservice/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/domain/repository/UserRepository.java
@@ -17,11 +17,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByEmail(String email);
 
-	Optional<User> findByUsername(String username);
+	Optional<User> findByUsernameAndDeletedAtIsNull(String username);
 
 
 	// 관리자 전용 조회(Soft Delete 포함) - JPQL로 명시적 구현
-	// keyword로 username 또는 email 검색
 	@Query(value = """
 		SELECT DISTINCT u 
 		FROM User u 

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/controller/UserControllerV1.java
@@ -207,7 +207,7 @@ public class UserControllerV1 {
 	 * 관리자 전용: 모든 사용자 정보 조회 (Search/Paging/Sort)
 	 * MASTER/MANAGER 권한만 접근 가능
 	 */
-	@Secured("ROLE_MASTER") // 권한이 MASTER만 접근 가능
+	@Secured("ROLE_MANAGER") // 권한이 MASTER, MANAGER만 접근 가능
 	@GetMapping("/admin")
 	public ResponseEntity<ApiResponse<Page<UserResponseDto>>> searchUsers(
 		AdminSearchUserRequestDto requestDto // @RequestParam 파라미터가 DTO에 자동으로 바인딩

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/response/UserResponseDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/dto/response/UserResponseDto.java
@@ -27,9 +27,9 @@ public class UserResponseDto {
 		this.createdAt = user.getCreatedAt();
 		this.deletedAt = user.getDeletedAt();
 
-		// Soft Delete 되지 않은 주소만 필터링하여 반환
+		// 전체 주소 반환(UserServiceV1의 관리자 전용 조회 메서드(세선 필터)에서 제어)
 		this.addressList = user.getAddressList().stream()
-			.filter(address -> address.getDeletedAt() == null)
+			// .filter(address -> address.getDeletedAt() == null)
 			.map(AddressResponseDto::new)
 			.collect(Collectors.toList());
 	}


### PR DESCRIPTION
🚩 관련 이슈

- 현재 Address의 Soft Delete된 데이터가 조회되지않는 현상이 발생하고있습니다.(에러 해결)
- 회원탈퇴한 유저(Soft Delete)의 로그인을 못하게 막았습니다.



📋 관련 이슈 명세

- 마이페이지 조회 시, 세션 필터의 파라미터 false / 관리자 전용 조회 시, 세션필터 파라미터 true로 설정
   UserResponseDto에서 addaddresslist의 Stream 일부 주석처리
- // .filter(address -> address.getDeletedAt() == null)

- UserRepository와 UserDetailsServiceImpl의 findByUsername(String username) 메서드를 
  findByUsernameAndDeletedAtIsNull(String username)로 변경  
 


📌 PR Point

- 수정할 코드가 있는지

- 이해가 잘 가는지

- 잘못된 부분이 있는지

