### PR TITLE
[Feature/#27] 주문 조회 기능 개발

### DIFF
--- a/src/main/java/com/opportunity/deliveryservice/order/application/service/OrderQueryServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/application/service/OrderQueryServiceV1.java
@@ -60,8 +60,9 @@ public class OrderQueryServiceV1 {
 		return orders.stream()
 			.map(o -> {
 				OrderProduct orderProduct = opByOrderId.get(o.getId());
-				ResOrderProductDto productDto = orderProduct != null ? ResOrderProductDto.fromEntity(orderProduct) : null;
-				return ResOrderListDto.fromEntity(o,productDto);
+				ResOrderProductDto productDto = orderProduct != null
+					? ResOrderProductDto.fromEntity(orderProduct) : null;
+				return ResOrderListDto.fromEntity(o, productDto);
 			})
 			.toList();
 	}

--- a/src/main/java/com/opportunity/deliveryservice/order/application/service/OrderQueryServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/application/service/OrderQueryServiceV1.java
@@ -1,0 +1,96 @@
+package com.opportunity.deliveryservice.order.application.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.opportunity.deliveryservice.global.common.code.ClientErrorCode;
+import com.opportunity.deliveryservice.global.common.exception.OpptyException;
+import com.opportunity.deliveryservice.global.infrastructure.config.security.UserDetailsImpl;
+import com.opportunity.deliveryservice.order.domain.entity.Order;
+import com.opportunity.deliveryservice.order.domain.entity.OrderProduct;
+import com.opportunity.deliveryservice.order.domain.repository.OrderPaymentRepository;
+import com.opportunity.deliveryservice.order.domain.repository.OrderProductRepository;
+import com.opportunity.deliveryservice.order.domain.repository.OrderRepository;
+import com.opportunity.deliveryservice.order.presentation.dto.response.ResOrderDetailDto;
+import com.opportunity.deliveryservice.order.presentation.dto.response.ResOrderListDto;
+import com.opportunity.deliveryservice.order.presentation.dto.response.ResOrderProductDto;
+import com.opportunity.deliveryservice.payment.domain.entity.Payment;
+import com.opportunity.deliveryservice.user.domain.entity.UserRoleEnum;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderQueryServiceV1 {
+	private final OrderRepository orderRepository;
+	private final OrderProductRepository orderProductRepository;
+	private final OrderPaymentRepository orderPaymentRepository;
+
+	// 주문 내역 조회
+	public List<ResOrderListDto> getOrders(UserDetailsImpl user) {
+		// 권한에 따라 조회 메서드 선택
+		List<Order> orders;
+
+		if (user.getUser().getRole() == UserRoleEnum.MASTER) {
+			// MASTER: 모든 주문 목록 조회
+			orders = orderRepository.findAllByOrderByCreatedAtDesc();
+		} else if (user.getUser().getRole() == UserRoleEnum.CUSTOMER) {
+			// CUSTOMER: 자신의 주문 목록 조회
+			orders = orderRepository.findAllByUserIdOrderByCreatedAtDesc(user.getUser().getId());
+		} else {
+			throw new OpptyException(ClientErrorCode.FORBIDDEN);
+		}
+
+		// 해당 주문 목록의 orderProduct 조회
+		List<UUID> orderIds = orders.stream().map(Order::getId).toList();
+		List<OrderProduct> orderProducts = orderProductRepository.findAllByOrder_In(orderIds);
+
+		// orderId -> OrderProduct (주문id -> 상품 정보) 매핑
+		Map<UUID, OrderProduct> opByOrderId = orderProducts.stream()
+			.collect(Collectors.toMap(OrderProduct::getOrderId, Function.identity()));
+
+		// dto로 반환
+		return orders.stream()
+			.map(o -> {
+				OrderProduct orderProduct = opByOrderId.get(o.getId());
+				ResOrderProductDto productDto = orderProduct != null ? ResOrderProductDto.fromEntity(orderProduct) : null;
+				return ResOrderListDto.fromEntity(o,productDto);
+			})
+			.toList();
+	}
+
+	// 주문 상세 내역 조회
+	public ResOrderDetailDto getOrderDetail(UUID orderId, UserDetailsImpl user) {
+		// 권한에 따라 조회 메서드 선택
+		Order order;
+
+		if (user.getUser().getRole() == UserRoleEnum.MASTER) {
+			// MASTER: 모든 주문 목록 조회
+			order = orderRepository.findById(orderId)
+				.orElseThrow(() -> new OpptyException(ClientErrorCode.RESOURCE_NOT_FOUND));
+		} else if (user.getUser().getRole() == UserRoleEnum.CUSTOMER) {
+			// CUSTOMER: 자신의 주문 목록 조회
+			order = orderRepository.findByIdAndUserId(orderId, user.getUser().getId())
+				.orElseThrow(() -> new OpptyException(ClientErrorCode.RESOURCE_NOT_FOUND));
+		} else {
+			throw new OpptyException(ClientErrorCode.FORBIDDEN);
+		}
+
+		// 결제 정보 조회
+		Payment payment = orderPaymentRepository.findByOrder(order)
+			.orElse(null); // 결제 정보가 없는 주문
+
+		// 상품 정보 조회
+		OrderProduct orderProduct = orderProductRepository.findByOrder(order)
+			.orElseThrow(() -> new OpptyException(ClientErrorCode.RESOURCE_NOT_FOUND));
+
+		return ResOrderDetailDto.fromEntity(order, orderProduct, payment);
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/order/domain/entity/OrderProduct.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/domain/entity/OrderProduct.java
@@ -33,6 +33,17 @@ public class OrderProduct {
 
 	Long productQuantity;
 
+	// 주문 조회
+	String productImage;
+
+	UUID storeId;
+
+	String storeName;
+
+	public UUID getOrderId() {
+		return this.order != null ? this.order.getId() : null;
+	}
+
 	@Builder
 	public OrderProduct(Order order, Long productPrice, String productTitle, UUID productId, Long productQuantity){
 		this.order = order;

--- a/src/main/java/com/opportunity/deliveryservice/order/domain/repository/OrderPaymentRepository.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/domain/repository/OrderPaymentRepository.java
@@ -1,0 +1,15 @@
+package com.opportunity.deliveryservice.order.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.opportunity.deliveryservice.order.domain.entity.Order;
+import com.opportunity.deliveryservice.payment.domain.entity.Payment;
+
+@Repository
+public interface OrderPaymentRepository extends JpaRepository<Payment, UUID> {
+	Optional<Payment> findByOrder(Order order);
+}

--- a/src/main/java/com/opportunity/deliveryservice/order/domain/repository/OrderProductRepository.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/domain/repository/OrderProductRepository.java
@@ -1,10 +1,19 @@
 package com.opportunity.deliveryservice.order.domain.repository;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import com.opportunity.deliveryservice.order.domain.entity.Order;
 import com.opportunity.deliveryservice.order.domain.entity.OrderProduct;
 
+@Repository
 public interface OrderProductRepository extends JpaRepository<OrderProduct, UUID> {
+	// 주문 조회
+	Optional<OrderProduct> findByOrder(Order order);
+	List<OrderProduct> findAllByOrder_In(Collection<UUID> orderIds);
 }

--- a/src/main/java/com/opportunity/deliveryservice/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/domain/repository/OrderRepository.java
@@ -1,10 +1,19 @@
 package com.opportunity.deliveryservice.order.domain.repository;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.opportunity.deliveryservice.order.domain.entity.Order;
 
+@Repository
 public interface OrderRepository extends JpaRepository<Order, UUID> {
+	// 주문 조회
+	List<Order> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+	List<Order> findAllByOrderByCreatedAtDesc();
+	Optional<Order> findById(UUID id);
+	Optional<Order> findByIdAndUserId(UUID orderId, Long userId);
 }

--- a/src/main/java/com/opportunity/deliveryservice/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/presentation/controller/OrderController.java
@@ -1,4 +1,4 @@
-package com.opportunity.deliveryservice.order.presentation;
+package com.opportunity.deliveryservice.order.presentation.controller;
 
 import java.util.UUID;
 
@@ -15,7 +15,6 @@ import com.opportunity.deliveryservice.global.infrastructure.config.security.Use
 import com.opportunity.deliveryservice.order.application.service.OrderService;
 import com.opportunity.deliveryservice.order.presentation.dto.request.CancelOrderRequest;
 import com.opportunity.deliveryservice.order.presentation.dto.request.CreateOrderRequest;
-import com.opportunity.deliveryservice.product.presentation.dto.request.CreateProductRequest;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/opportunity/deliveryservice/order/presentation/controller/OrderQueryControllerV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/presentation/controller/OrderQueryControllerV1.java
@@ -1,0 +1,42 @@
+package com.opportunity.deliveryservice.order.presentation.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.opportunity.deliveryservice.global.common.response.ApiResponse;
+import com.opportunity.deliveryservice.global.infrastructure.config.security.UserDetailsImpl;
+import com.opportunity.deliveryservice.order.application.service.OrderQueryServiceV1;
+import com.opportunity.deliveryservice.order.presentation.dto.response.ResOrderDetailDto;
+import com.opportunity.deliveryservice.order.presentation.dto.response.ResOrderListDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/orders")
+@RequiredArgsConstructor
+public class OrderQueryControllerV1 {
+	private final OrderQueryServiceV1 orderQueryService;
+
+	// 주문 내역 조회
+	@GetMapping
+	public ApiResponse<List<ResOrderListDto>> getOrders(@AuthenticationPrincipal UserDetailsImpl user) {
+		List<ResOrderListDto> orderList = orderQueryService.getOrders(user);
+		return ApiResponse.success(orderList);
+	}
+
+	// 주문 상세 내역 조회
+	@GetMapping("{orderId}")
+	public ApiResponse<ResOrderDetailDto> getOrderDetail(
+		@PathVariable UUID orderId,
+		@AuthenticationPrincipal UserDetailsImpl user
+	) {
+		ResOrderDetailDto detail = orderQueryService.getOrderDetail(orderId, user);
+		return ApiResponse.success(detail);
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/order/presentation/dto/response/ResOrderDetailDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/presentation/dto/response/ResOrderDetailDto.java
@@ -1,0 +1,42 @@
+package com.opportunity.deliveryservice.order.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.opportunity.deliveryservice.order.domain.entity.Order;
+import com.opportunity.deliveryservice.order.domain.entity.OrderProduct;
+import com.opportunity.deliveryservice.order.domain.entity.OrderProgress;
+import com.opportunity.deliveryservice.payment.domain.entity.Payment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResOrderDetailDto {
+	private UUID orderId; // 주문 번호
+	private Integer amount; // 총 주문 금액
+	private OrderProgress orderProgress; // 주문 상태
+	private LocalDateTime createdAt; // 주문 생성일
+	private String request; // 요청사항
+	private ResOrderProductDto product; // 주문 상품 정보
+	private ResOrderPaymentDto payment; // 주문 결제 정보
+	private String productImage; // 주문 상품 사진
+	private UUID storeId; // 가게 id
+	private String storeName; // 가게 이름
+
+	public static ResOrderDetailDto fromEntity(Order order, OrderProduct orderProduct, Payment payment) {
+		return ResOrderDetailDto.builder()
+			.orderId(order.getId())
+			.amount(order.getAmount())
+			.orderProgress(order.getProgress())
+			.createdAt(order.getCreatedAt())
+			.request(order.getRequest())
+			.product(orderProduct != null ? ResOrderProductDto.fromEntity(orderProduct) : null)
+			.payment(payment != null ? ResOrderPaymentDto.fromEntity(payment) : null)
+			.productImage(orderProduct.getProductImage())
+			.storeId(orderProduct.getStoreId())
+			.storeName(orderProduct.getStoreName())
+			.build();
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/order/presentation/dto/response/ResOrderListDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/presentation/dto/response/ResOrderListDto.java
@@ -1,0 +1,30 @@
+package com.opportunity.deliveryservice.order.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.opportunity.deliveryservice.order.domain.entity.Order;
+import com.opportunity.deliveryservice.order.domain.entity.OrderProgress;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResOrderListDto {
+	private UUID orderId;
+	private Integer amount; // 총 주문 금액
+	private OrderProgress orderProgress;
+	private LocalDateTime createdAt;
+	private ResOrderProductDto product;
+
+	public static ResOrderListDto fromEntity(Order order, ResOrderProductDto product) {
+		return ResOrderListDto.builder()
+			.orderId(order.getId())
+			.amount(order.getAmount())
+			.orderProgress(order.getProgress())
+			.createdAt(order.getCreatedAt())
+			.product(product)
+			.build();
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/order/presentation/dto/response/ResOrderPaymentDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/presentation/dto/response/ResOrderPaymentDto.java
@@ -1,0 +1,25 @@
+package com.opportunity.deliveryservice.order.presentation.dto.response;
+
+import com.opportunity.deliveryservice.payment.domain.entity.Payment;
+import com.opportunity.deliveryservice.payment.domain.entity.PaymentStatus;
+import com.opportunity.deliveryservice.payment.domain.entity.TossPaymentMethod;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResOrderPaymentDto {
+	private TossPaymentMethod method;
+	private Integer amount;
+	private PaymentStatus status;
+
+	public static ResOrderPaymentDto fromEntity(Payment payment) {
+		if (payment == null) return null; // 결제가 없는 주문 null 허용
+		return ResOrderPaymentDto.builder()
+			.method(payment.getMethod())
+			.amount(payment.getAmount())
+			.status(payment.getStatus())
+			.build();
+	}
+}

--- a/src/main/java/com/opportunity/deliveryservice/order/presentation/dto/response/ResOrderProductDto.java
+++ b/src/main/java/com/opportunity/deliveryservice/order/presentation/dto/response/ResOrderProductDto.java
@@ -1,0 +1,32 @@
+package com.opportunity.deliveryservice.order.presentation.dto.response;
+
+import java.util.UUID;
+
+import com.opportunity.deliveryservice.order.domain.entity.OrderProduct;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResOrderProductDto {
+	private UUID productId;
+	private String productTitle;
+	private Long productPrice;
+	private Long productQuantity;
+	private String productImage;
+	private UUID storeId;
+	private String storeName;
+
+	public static ResOrderProductDto fromEntity(OrderProduct orderProduct) {
+		return ResOrderProductDto.builder()
+			.productId(orderProduct.getProductId())
+			.productTitle(orderProduct.getProductTitle())
+			.productPrice(orderProduct.getProductPrice())
+			.productQuantity(orderProduct.getProductQuantity())
+			.productImage(orderProduct.getProductImage())
+			.storeId(orderProduct.getStoreId())
+			.storeName(orderProduct.getStoreName())
+			.build();
+	}
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #27 

## 📋 구현 기능 명세
- [x] 주문 내역 조회
- [x] 주문 상세 내역 조회

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지

**CUSTOMER**
주문 내역 조회: 유저 자신이 생성한 주문 목록
주문 상세 내역 조회:  주문 단건 상세 내역

**MASTER**
주문 내역 조회: 유저들이 생성한 모든 주문 내역 목록
주문 상세 내역 조회: 유저가 생성한 주문 단건 상세 내역

<br>

- 어떤 부분에 리뷰어가 집중해야 하는지

주문 상품 중간 테이블(orderProducts)은 주문 당시의 내역을 저장하기 위한 테이블입니다.(스냅샷 테이블)
주문에서 주문상품 정보를 알기 위해 orderProducts에 주문이 저장될 때 필요한 데이터를 모두 저장하도록 엔티티를 수정했습니다.



