### PR TITLE
[#17] fix: 회원수정 & 탈퇴시, 로그아웃 처리 / @Filter와 FETCH JOIN간의 데이터 불일치 해결

### DIFF
--- a/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/application/service/UserServiceV1.java
@@ -198,6 +198,10 @@ public class UserServiceV1 {
 			encodedNewPassword = passwordEncoder.encode(requestDto.getNewPassword());
 		}
 
+		if (userRepository.existsByEmail((requestDto.getEmail()))) {
+			throw new OpptyException(ClientErrorCode.DUPLICATE_EMAIL);
+		}
+
 		// 2. 정보 업데이트
 		user.update(requestDto, encodedNewPassword);
 	}

--- a/src/main/java/com/opportunity/deliveryservice/user/domain/entity/User.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/domain/entity/User.java
@@ -3,6 +3,7 @@ package com.opportunity.deliveryservice.user.domain.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.ParamDef;
@@ -60,6 +61,7 @@ public class User extends BaseEntity {
 
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Filter(name = "deletedAddressFilter", condition = "deleted_at IS NULL OR :isDeleted = true")
+	@BatchSize(size = 100)
 	private List<Address> addressList = new ArrayList<>();
 
 	public User(UserSignupRequestDto requestDto, String encodedPassword) {

--- a/src/main/java/com/opportunity/deliveryservice/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/domain/repository/UserRepository.java
@@ -24,7 +24,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Query(value = """
 		SELECT DISTINCT u 
 		FROM User u 
-		JOIN FETCH u.addressList
 		WHERE 
 		    (:keyword IS NULL OR u.username LIKE :keyword OR u.email LIKE :keyword)
 		    AND (:role IS NULL OR u.role = :role)

--- a/src/main/java/com/opportunity/deliveryservice/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/opportunity/deliveryservice/user/presentation/controller/UserControllerV1.java
@@ -142,11 +142,23 @@ public class UserControllerV1 {
 	@PutMapping("/me")
 	public ResponseEntity<ApiResponse<Void>> updateProfile(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
-		@Valid @RequestBody UserUpdateRequestDto requestDto
+		@Valid @RequestBody UserUpdateRequestDto requestDto,
+		@CookieValue(value = JwtUtil.REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+		HttpServletRequest request,
+		HttpServletResponse response
 	) {
 		userService.updateUser(userDetails.getUser().getId(), requestDto, userDetails.getUser());
+
+		// 비밀번호 변경 시 기존 토큰 폐기
+		if (requestDto.getNewPassword() != null) {
+			String accessToken = JwtUtil.getJwtFromHeader(request);
+			userService.logout(accessToken, refreshToken);
+			jwtUtil.deleteCookie(response, JwtUtil.REFRESH_TOKEN_COOKIE_NAME);
+		}
+
 		return ResponseEntity.ok(ApiResponse.successNoData("200 OK", "회원정보 수정에 성공했습니다!"));
 	}
+
 
 	/**
 	 * 회원 탈퇴 (Soft Delete)
@@ -154,11 +166,21 @@ public class UserControllerV1 {
 	@DeleteMapping("/me")
 	public ResponseEntity<ApiResponse<Void>> deleteUser(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
-		@RequestBody UserDeleteRequestDto requestDto
+		@RequestBody UserDeleteRequestDto requestDto,
+		@CookieValue(value = JwtUtil.REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+		HttpServletRequest request,
+		HttpServletResponse response
 	) {
 		userService.deleteUser(userDetails.getUser().getId(), requestDto.getPassword(), userDetails.getUser());
+
+		// 탈퇴 후 기존 토큰 폐기
+		String accessToken = JwtUtil.getJwtFromHeader(request);
+		userService.logout(accessToken, refreshToken);
+		jwtUtil.deleteCookie(response, JwtUtil.REFRESH_TOKEN_COOKIE_NAME);
+
 		return ResponseEntity.ok(ApiResponse.successNoData("200 OK", "성공적으로 회원탈퇴되었습니다!"));
 	}
+
 
 	// --- 주소록 (Address) CRUD ---
 


### PR DESCRIPTION
🚩 관련 이슈

- 기존 회원수정, 탈퇴시, 수정/탈퇴 후 로그아웃 로직 Controller에 추가
- 회원 수정에서 이메일 중복 확인 로직 추가

📋 구현 기능 명세




📌 PR Point

- 수정할 코드가 있는지

- 이해가 잘 가는지

- 잘못된 부분이 있는지

